### PR TITLE
remove deploy job from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,19 +2,10 @@ version: 2.1
 orbs:
   heroku: circleci/heroku@0.0.8
 workflows:
-  heroku_deploy:
+  deploy:
     jobs:
       - install
-      - deploy:
-          requires:
-            - install
 jobs:
-  deploy:
-    executor: heroku/default
-    steps:
-      - heroku/install
-      - heroku/deploy-via-git:
-          only-branch: master
   install:
     docker:
       - image: circleci/ruby:2.5.1


### PR DESCRIPTION
This PR renames the `heroku_deploy` workflow and removes the `deploy` job.