### PR TITLE
Add Procfile to specify rake command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+heroku run rails db:migrate


### PR DESCRIPTION
This PR adds a Procfile for Heroku to specify the command to start the server and to run a rails rake db migration.