### PR TITLE
change procfile to add release context

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
-heroku run rails db:migrate
+release: rake db:migrate


### PR DESCRIPTION
This PR edits the Procfile to add a release context for deploying to Heroku. `release` specifies what commands to run after building the app. This solves the issue when deploying current branch to heroku.