### PR TITLE
Integrate CircleCI and RSpec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,13 @@ workflows:
       - lint:
           requires:
             - install
+      - test:
+          requires:
+            -install
       - deploy:
           requires:
             - lint
+            - test
             - install
 jobs:
   lint:
@@ -28,6 +32,14 @@ jobs:
       - run:
           name: Run Rubocop
           command: bundle exec rubocop
+  test:
+    docker: 
+      - image: circleci/ruby:2.5.1
+    steps:
+      - checkout
+      - run:
+          name: Test
+          command: bundle install && bundle exec rspec
   deploy:
     executor: heroku/default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
             - install
       - test:
           requires:
-            -install
+            - install
       - deploy:
           requires:
             - lint


### PR DESCRIPTION
Description of CircleCI config changes:
+ added `test` job to run tests using RSpec
+ added `test` job to the `heroku_deploy` workflow

See [here](https://circleci.com/gh/uwblueprint/sdc-api/172) for an example of a successful build.